### PR TITLE
Improved responsive layout for exchange overview

### DIFF
--- a/src/app/exchange-asset-pair/exchange-asset-pair.component.css
+++ b/src/app/exchange-asset-pair/exchange-asset-pair.component.css
@@ -77,7 +77,7 @@ a {
 }
 
 .chart-wrapper {
-  height: 187px;
+  height: 160px;
   /* width: 362px; */
 }
 

--- a/src/app/exchange-asset-pair/exchange-asset-pair.component.ts
+++ b/src/app/exchange-asset-pair/exchange-asset-pair.component.ts
@@ -166,6 +166,7 @@ export class ExchangeAssetPairComponent implements OnInit, OnChanges, OnDestroy 
     return {
       title: { display: false },
       legend: { display: false },
+      maintainAspectRatio: false,
       scales: {
         yAxes: [{
           display: false,

--- a/src/app/exchange-overview/exchange-overview.component.css
+++ b/src/app/exchange-overview/exchange-overview.component.css
@@ -5,10 +5,6 @@
   align-content: stretch;
 }
 
-/* .flexItem {
-  flex-basis: 19.95%;
-} */
-
 .flexItem {
   /* set min-width to 0 so that the chart-js will be shrinked as soon as the scroll-bar appears
   * without this setting the flex-item won't shrink past its content size */
@@ -17,24 +13,30 @@
 
 @media (min-width: 1572px) {
   .flexItem {
-     flex-basis: 20%;
+    flex-basis: 20%;
   }
 }
 
 @media (max-width: 1572px) and (min-width: 1175px) {
- .flexItem {
-   flex-basis: 25%;
- }
+  .flexItem {
+    flex-basis: 25%;
+  }
 }
 
 @media (max-width: 1175px) and (min-width: 900px) {
- .flexItem {
-   flex-basis: 33%;
- }
+  .flexItem {
+    flex-basis: 33%;
+  }
 }
 
-@media (max-width: 900px) {
- .flexItem {
-   flex-basis: 50%;
- }
+@media (max-width: 900px) and (min-width: 640px) {
+  .flexItem {
+    flex-basis: 50%;
+  }
+}
+
+@media (max-width: 640px) {
+  .flexItem {
+    flex-basis: 100%;
+  }
 }


### PR DESCRIPTION
This pull request fixes two problems which appeared on the exchange-overview page:

1. When shrinking the browser window to a certain width, the charts tried to maintain their aspect ratio while ignoring the height of their parent's DOM-element. Sometimes they were so huge that they overlapped with their neighbour DOM-elements. Fortunately we don't even need aspect-maintaining on this page, so we just have to disable it to fix the problem.
2. Added media-query css-rule for mobile-view to display only one asset-column as long as the browser doesn't exceed a certain width (640px) - there's not enough width for two columns.